### PR TITLE
When package httpv1 func use logger , it always trigger painc .

### DIFF
--- a/httpv1/http.go
+++ b/httpv1/http.go
@@ -26,8 +26,8 @@ var (
 	logger *logrus.Logger
 )
 
-func SetLogger(logger *logrus.Logger) {
-	logger = logger
+func SetLogger(l *logrus.Logger) {
+	logger = l
 }
 
 func Version(serverVersion string) func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
http: panic serving 127.0.0.1:32946: runtime error: invalid memory address or nil pointer dereference
goroutine 591 [running]:
net/http.(*conn).serve.func1(0xc0004e86e0)
        /usr/local/go/src/net/http/server.go:1800 +0x139
panic(0xb37ee0, 0x1228fb0)
        /usr/local/go/src/runtime/panic.go:975 +0x3e3
github.com/sirupsen/logrus.(*Logger).level(...)
        /go/src/gua/vendor/github.com/sirupsen/logrus/logger.go:299
github.com/sirupsen/logrus.(*Logger).IsLevelEnabled(...)
        /go/src/gua/vendor/github.com/sirupsen/logrus/logger.go:321
github.com/sirupsen/logrus.(*Logger).Log(0x0, 0xc000000003, 0xc000385928, 0x2, 0x2)
        /go/src/gua/vendor/github.com/sirupsen/logrus/logger.go:190 +0x26
github.com/sirupsen/logrus.(*Logger).Warn(...)
        /go/src/gua/vendor/github.com/sirupsen/logrus/logger.go:216
github.com/syhlion/gua/httpv1.RegisterGroup.func1(0xd2ebc0, 0xc0004321c0, 0xc000436400)
        /go/src/gua/httpv1/http.go:264 +0x3aa
net/http.HandlerFunc.ServeHTTP(0xc0000d6200, 0xd2ebc0, 0xc0004321c0, 0xc000436400)
        /usr/local/go/src/net/http/server.go:2041 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0000fa000, 0xd2ebc0, 0xc0004321c0, 0xc000436100)
        /go/src/gua/vendor/github.com/gorilla/mux/mux.go:212 +0xe2
github.com/gorilla/handlers.(*cors).ServeHTTP(0xc000422240, 0xd2ebc0, 0xc0004321c0, 0xc000436100)
        /go/src/gua/vendor/github.com/gorilla/handlers/cors.go:52 +0xffc
net/http.serverHandler.ServeHTTP(0xc000432000, 0xd2ebc0, 0xc0004321c0, 0xc000436100)
        /usr/local/go/src/net/http/server.go:2836 +0xa3
net/http.(*conn).serve(0xc0004e86e0, 0xd30b80, 0xc0002f1e40)
        /usr/local/go/src/net/http/server.go:1924 +0x86c
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:2962 +0x35c