### PR TITLE
docs: add Traditional Chinese (zh-TW) docs

### DIFF
--- a/EVAL.md
+++ b/EVAL.md
@@ -1,5 +1,7 @@
 # gua as a JobScheduler replacement — evaluation & migration
 
+> 🌐 **English** · [繁體中文](EVAL.zh-TW.md)
+
 Light evaluation (JobScheduler usage is small; breaking changes are acceptable).
 
 ## Feature parity

--- a/EVAL.zh-TW.md
+++ b/EVAL.zh-TW.md
@@ -1,0 +1,61 @@
+# gua 取代 JobScheduler —— 評估與遷移
+
+> 🌐 [English](EVAL.md) · **繁體中文**
+
+輕量評估（JobScheduler 使用量少;破壞性變更可接受）。
+
+## 功能對位
+
+| 能力 | gua |
+|---|---|
+| 一次性 / cron / 間隔排程 | ✅ `@once`、6 欄位 cron、`@every` |
+| 動態 新增 / 編輯 / 暫停 / 恢復 / 刪除 | ✅ REST + gRPC |
+| 投遞給消費者 | ✅ HTTP POST 信封 **或** gRPC `OnJobTrigger`(Push） |
+| 叢集 / HA | ✅ 無狀態水平擴展（SKIP LOCKED） |
+| 監控 | ✅ `/v1/status`、per-group 執行歷史、`/ui` |
+
+結論:**功能上涵蓋 JobScheduler,並多了結構化 gRPC 投遞 + 內建監控。**
+
+## 消費者的破壞性變更
+
+1. **投遞型別只剩 HTTP / gRPC**。遠端 shell（REMOTE）與 in-process Lua（LUA）已移除。
+2. **HTTP callback 改成 `POST` + JSON 信封**（原本是 `GET` ping）。消費者要收 POST、讀 body。
+3. **`payload` 取代 `exec_command`**（字串,觸發時原樣交還）。
+4. **沒有 app 層 OTP**。`register_group` 不再回 secret;callback 不帶 `otp_code`。需要的話把認證放傳輸層（mTLS / gateway / network policy）。
+
+遷移 = 每個相依方把 callback endpoint 改成收 POST 信封（或實作 gRPC
+`GuaCallback`),並拔掉 OTP 處理。
+
+## 投遞語意
+
+**At-least-once。** `FOR UPDATE SKIP LOCKED` 讓「撈取」在整個叢集是 exactly-once
+（壓測顯示 2k 同刻 job 0 重複),但 River 會重試失敗、並把崩潰 worker 的 job 撿
+回,所以一個 job 仍可能被「投遞」超過一次 —— 消費端必須**冪等**。
+
+## 時間特性（Postgres / River）
+
+排在未來的 job 由 River 的 scheduler 提升(promote),相對於舊的 in-memory ticker
+會多幾秒延遲。壓測（單節點、HTTP 投遞、真 Postgres):N 個 job 排在同一刻 →
+
+| N | 漏觸發 | 重複 | lateness p50 | p99 | max |
+|---|---|---|---|---|---|
+| 500 | 0 | 0 | ~3.0s | ~3.5s | ~3.5s |
+| 2000 | 0 | 0 | ~4.2s | ~6.3s | ~6.3s |
+
+完整性 + 無重複的不變式全程成立（`SKIP LOCKED`)。lateness 是 River 的提升延遲 +
+把 N 個 job 經由 worker pool 排空 —— **不是漏觸發**。對分鐘/小時級排程無感;若要
+sub-second 精度,Postgres/River 不是對的底層(`harden` 上的 Redis 線有 700ms 地板)。
+
+## 殘留風險 / 後續
+
+- **投遞是 at-least-once** —— `SKIP LOCKED` 讓撈取 exactly-once,但「投遞成功後、
+  commit 前崩潰」(或 River rescuer)可能重投。消費端必須**冪等**。
+- **未來 job 延遲**(如上)—— River 提升排定 job 需要幾秒。對目標用途可接受,寫
+  明只是別期待 sub-second。
+- **River 是 pre-1.0**(`v0.x`)—— 活躍維護（MPL-2.0),但 API 未凍結;釘版本、
+  升級時複檢。
+- **Postgres 是唯一真實來源** —— 用正常的持久化(replication / backup)。一顆 DB、
+  一個 failure domain —— 但 ACID,所以不用自己寫恢復碼。
+- **上線**:與舊排程器並行部署,一次搬一個相依方(把它的 job 指向 gua、改它的
+  callback),看 `/ui` + 歷史;回退就把相依方指回去。**全新 Postgres 部署不需要
+  資料遷移**,只有「原地把跑著的 Redis 切過去」才需要。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gua
 
+> 🌐 **English** · [繁體中文](README.zh-TW.md)
+
 Distributed crontab-style scheduler in Go, backed by **PostgreSQL** (via
 [River](https://riverqueue.com)).
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,56 @@
+# gua
+
+> 🌐 [English](README.md) · **繁體中文**
+
+以 Go 實作的分散式 crontab 風格排程器,後端為 **PostgreSQL**(透過
+[River](https://riverqueue.com))。
+
+Job 註冊在某個 group 底下,在排定時間觸發(一次性 `@once`、cron、或 `@every`)。
+當 job 觸發時,gua 會把一份 **trigger 信封** 透過兩種傳輸之一送給消費者:
+
+- **HTTP** — 對 `<target>` 發 `POST`,body 為 JSON
+- **gRPC** — `OnJobTrigger`(Push:gua 主動 dial 消費者的 gRPC server)
+
+兩者帶相同欄位:`job_id`、`job_name`、`group_name`、`plan_time`、`exec_time`、
+`payload`。消費者的 HTTP `2xx` / gRPC `JobResult` 即為執行結果,會記進短期保留的
+歷史供監控查詢。
+
+> 這是 PostgreSQL 線。Redis 版保留在 `harden` 分支;後端為什麼、怎麼搬到
+> Postgres,見 [docs/pg-migration.zh-TW.md](docs/pg-migration.zh-TW.md)。
+
+## 使用
+
+```
+$ ./gua start -e env.river.example     # 用 env 檔
+$ ./gua start                          # 或直接讀 process 環境變數
+```
+
+需要一顆可連的 Postgres(`PG_DSN`);River 開機時會自己跑 migration。所有設定
+(Postgres、歷史保留、logging + 滾動)見 [env.river.example](env.river.example)。
+
+## 架構
+
+![architecture](docs/diagrams/gua-architecture.png)
+
+gua 節點是**無狀態**的:全部對同一顆 Postgres 用 `FOR UPDATE SKIP LOCKED` 撈
+job,所以每個 job 在整個叢集只跑一次——沒有 slot 選舉、沒有 per-node bucket、
+沒有去重 fence。加一台節點它就直接開始撈;某台崩潰時,它手上正在跑的 job 由
+River 的 rescuer 撿回。完整說明(pipeline、HA、schema)見
+[docs/ARCHITECTURE.zh-TW.md](docs/ARCHITECTURE.zh-TW.md)。
+
+## 文件
+
+- [docs/ARCHITECTURE.zh-TW.md](docs/ARCHITECTURE.zh-TW.md) — 架構、pipeline、HA(含圖)
+- [apiv1.zh-TW.md](./apiv1.zh-TW.md) — admin REST API
+- [`proto/gua.proto`](./proto/gua.proto) — gRPC `GuaAdmin` + `GuaCallback`
+- [docs/MONITORING.zh-TW.md](docs/MONITORING.zh-TW.md) — `/v1/status`、`/v1/{group}/history`、`/ui`、logging
+- [EVAL.zh-TW.md](./EVAL.zh-TW.md) — 取代 JobScheduler 的評估與遷移
+
+## 測試
+
+```
+go test ./...                                          # 單元測試(cron parser)
+# 整合 / 壓測需要 Postgres:
+GUA_PG_DSN='postgres://user:pass@host:5432/db?sslmode=disable' go test ./delayquene/ -run TestRiver
+GUA_STRESS=1 GUA_STRESS_N=2000 GUA_PG_DSN=... go test ./delayquene/ -run TestRiverStress -v
+```

--- a/apiv1.md
+++ b/apiv1.md
@@ -1,5 +1,7 @@
 # gua admin API (v1)
 
+> 🌐 **English** · [繁體中文](apiv1.zh-TW.md)
+
 Base path `/v1`. Bodies are JSON. Responses are wrapped as `{"success": ...}`.
 There is no app-level auth (see [EVAL.md](./EVAL.md)); protect at the transport
 layer (network policy / mTLS / gateway) as needed.

--- a/apiv1.zh-TW.md
+++ b/apiv1.zh-TW.md
@@ -1,0 +1,66 @@
+# gua admin API（v1）
+
+> 🌐 [English](apiv1.md) · **繁體中文**
+
+base path 為 `/v1`。body 為 JSON。回應包成 `{"success": ...}`。沒有 app 層認證
+（見 [EVAL.zh-TW.md](./EVAL.zh-TW.md)）；需要的話請在傳輸層（network policy /
+mTLS / gateway）保護。
+
+同樣的操作也可透過 gRPC `GuaAdmin` service 使用（`proto/gua.proto`）。
+
+## Group
+
+| Method | Path | Body | 說明 |
+|---|---|---|---|
+| POST | `/register/group` | `{"group_name":"G"}` | group 是命名空間 |
+| POST | `/remove/group` | `{"group_name":"G"}` | |
+| GET | `/group/list` | | |
+| GET | `/{group}/group/info` | | |
+
+## Job
+
+| Method | Path | Body |
+|---|---|---|
+| POST | `/add/job` | 見下 → 回傳 `job_id` |
+| POST | `/edit/job` | `{"group_name","id","request_url","payload"}` |
+| POST | `/pause/job` | `{"group_name","job_id"}` |
+| POST | `/active/job` | `{"group_name","job_id","exec_time"}` |
+| POST | `/delete/job` | `{"group_name","job_id"}` |
+| GET | `/{group}/job/list` | |
+| DELETE | `/{group}/job/clear` | |
+| DELETE | `/{group}/job/delete/{job_name}` | |
+
+### add/job 的 payload
+
+```json
+{
+  "group_name": "G",
+  "job_id": "",                 // 可選;空字串 → server 自動產生 snowflake id
+  "name": "daily-report",
+  "exec_time": 1782268640,      // unix 秒,首次觸發
+  "interval_pattern": "@once",  // "@once" | cron(秒 分 時 日 月 週)| "@every 1h"
+  "request_url": "HTTP@https://consumer/hook",  // 或 "GRPC@host:port"
+  "payload": "觸發時原樣交還給消費者的字串",
+  "timeout": 5,                 // 秒;作為 gRPC 呼叫 timeout
+  "memo": ""
+}
+```
+
+## 投遞（job 觸發時消費者收到什麼）
+
+兩種傳輸帶相同信封:
+
+- **HTTP** — 對 `<target>` 發 `POST`,body 為
+  `{"job_id","job_name","group_name","plan_time","exec_time","payload"}`。
+  回 `2xx` 視為成功;body 當作結果 message 留存。
+- **gRPC** — `GuaCallback.OnJobTrigger(JobTrigger) -> JobResult{success,message}`
+  （消費者實作;gua 主動 dial `target`）。
+
+## 監控
+
+| Method | Path | 說明 |
+|---|---|---|
+| GET | `/version` | |
+| GET | `/v1/status` | ready 佇列深度、down-server backlog、節點健康 |
+| GET | `/v1/{group}/history?limit=N` | 最近執行(成功/失敗、時間) |
+| GET | `/ui` | 一頁工程 console |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # gua architecture (PostgreSQL / River)
 
+> 🌐 **English** · [繁體中文](ARCHITECTURE.zh-TW.md)
+
 gua is a distributed, crontab-style scheduler backed by PostgreSQL via
 [River](https://riverqueue.com). Clients register jobs over **HTTP REST or
 gRPC**; when a job fires gua delivers a **trigger envelope** to the consumer

--- a/docs/ARCHITECTURE.zh-TW.md
+++ b/docs/ARCHITECTURE.zh-TW.md
@@ -1,0 +1,68 @@
+# gua 架構(PostgreSQL / River)
+
+> 🌐 [English](ARCHITECTURE.md) · **繁體中文**
+
+gua 是一套分散式、crontab 風格的排程器,後端為 PostgreSQL(透過
+[River](https://riverqueue.com))。客戶端用 **HTTP REST 或 gRPC** 註冊 job;job
+觸發時 gua 用 **HTTP POST 或 gRPC Push** 把 trigger 信封送給消費者。gua 節點無
+狀態、可水平擴展。
+
+> 圖的原始檔是每張 PNG 旁邊的 `.drawio` —— 用 draw.io 開即可編輯。
+
+## 系統總覽
+
+![architecture](diagrams/gua-architecture.png)
+
+- **註冊 / CRUD**(消費者 → gua):`RegisterGroup`、`AddJob`、`EditJob`、
+  `PauseJob`、`ActiveJob`、`DeleteJob`、`ListJobs` —— HTTP REST(`/v1/...`)與
+  等價的 gRPC `GuaAdmin` service。
+- **投遞**(gua → 消費者,job 觸發時):同一份信封
+  (`job_id, job_name, group_name, plan_time, exec_time, payload`)以 JSON `POST`
+  (HTTP)或 `GuaCallback.OnJobTrigger`(gRPC Push)送出。消費者的 `2xx` /
+  `JobResult` 即執行結果。
+- **監控**:`GET /v1/status`、`GET /v1/{group}/history`、Web console `GET /ui`。
+  見 [MONITORING.zh-TW.md](MONITORING.zh-TW.md)。
+
+## Pipeline
+
+![pipeline](diagrams/gua-pipeline.png)
+
+`AddJob` 把 job **定義**寫進 `gua_jobs`(真實來源),並用
+`river.Insert(ScheduledAt=run_at)` 排定一個 **occurrence**。River worker 用
+`FOR UPDATE SKIP LOCKED` 撈到期的 row(由 LISTEN/NOTIFY 喚醒),再確認定義仍是
+`active`、投遞信封、把這次嘗試記進 `gua_executions`。`@once` 投完即結束;recurring
+則用 cron `Next()` 重排下一個 occurrence。投遞失敗由 River 重試。
+
+- **投遞是 at-least-once**:River 會重試失敗、並把崩潰 worker 的 job 撿回,所以
+  一個 job 可能被投遞超過一次 —— **消費端必須冪等**。(`SKIP LOCKED` 讓「撈取」
+  是 exactly-once;會重投的是「投遞成功後、commit 前崩潰」那個窗口。)
+- **時間特性**:排在未來的 job 由 River 的 scheduler 提升(promote),相對於
+  in-memory ticker 會多幾秒延遲。對分鐘/小時級的排程無感;若要 sub-second 精度,
+  這就是換取持久性的代價。實測數字見 [EVAL.zh-TW.md](../EVAL.zh-TW.md)。
+
+## 叢集與 HA
+
+![cluster](diagrams/gua-cluster.png)
+
+無狀態水平擴展:每台節點都對同一顆 Postgres 用 `SKIP LOCKED` 撈,所以每個 job
+只會在一台節點上跑。**沒有** slot 選舉、owner-token fencing、per-node bucket、
+down-server 接管、或去重 fence —— 由 Postgres 的 row lock 做協調。River 自己跑
+leader election(PG advisory lock)來協調單例維護任務(scheduler / rescuer),
+其 rescuer 會把崩潰 worker 留下的 `running` job 撿回重跑。
+
+## Postgres schema
+
+| 表 | 用途 |
+|---|---|
+| `gua_jobs` | job 定義(active/paused)—— 真實來源 |
+| `gua_groups` | group 命名空間標記 |
+| `gua_executions` | 執行歷史(每次嘗試),依 `GUA_HISTORY_TTL` 修剪 |
+| `river_job`(+ River 的表) | 佇列:排定的 occurrence、重試、狀態 |
+
+## 延伸閱讀
+
+- [apiv1.zh-TW.md](../apiv1.zh-TW.md) — admin REST API
+- [`proto/gua.proto`](../proto/gua.proto) — gRPC `GuaAdmin` + `GuaCallback`
+- [MONITORING.zh-TW.md](MONITORING.zh-TW.md) — 狀態 / 歷史 / console / logging
+- [EVAL.zh-TW.md](../EVAL.zh-TW.md) — 取代 JobScheduler 評估
+- [pg-migration.zh-TW.md](pg-migration.zh-TW.md) — Redis → Postgres 遷移

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,5 +1,7 @@
 # gua monitoring
 
+> 🌐 **English** · [繁體中文](MONITORING.zh-TW.md)
+
 Three read paths, all served from the HTTP listener.
 
 ## `GET /v1/status` — queue health

--- a/docs/MONITORING.zh-TW.md
+++ b/docs/MONITORING.zh-TW.md
@@ -1,0 +1,70 @@
+# gua 監控
+
+> 🌐 [English](MONITORING.md) · **繁體中文**
+
+三條讀取路徑,全部由 HTTP listener 提供。
+
+## `GET /v1/status` — 佇列健康
+
+唯讀快照。
+
+```json
+{
+  "now": 1782268643,
+  "ready_queue_depth": 0,
+  "down_server_backlog": 0,
+  "servers": []
+}
+```
+
+| 欄位 | 意義 |
+|---|---|
+| `ready_queue_depth` | 待跑的 River occurrence 數(`river_job` 尚未執行) |
+| `down_server_backlog` | 恆為 0 —— Postgres 上沒有 per-node bucket |
+| `servers[]` | 恆為空 —— gua 節點無狀態、無 slot 選舉(為了 API 形狀保留) |
+
+## `GET /v1/{group}/history?limit=N` — 執行歷史
+
+某 group 最近的執行紀錄,由新到舊(`limit` 預設 100,上限 1000)。
+
+```json
+[
+  {
+    "seq": 42,
+    "job_id": "2069610792084312064",
+    "group_name": "SMOKE",
+    "type": "HTTP",
+    "plan_time": 1782268640,
+    "exec_time": 1782268640,
+    "finish_time": 1782268640,
+    "success": true,
+    "message": "sink-ok",
+    "exec_machine_host": "host-1"
+  }
+]
+```
+
+- 存在 `gua_executions` 表;worker 每次嘗試都記一筆,寫入時順手修剪掉超過保留
+  窗口的舊資料(不需要另外的 sweeper)。
+- **保留期** 由 env 設定:`GUA_HISTORY_TTL`(秒,預設 `432000` = 5 天);設 `0`
+  則完全關閉歷史記錄。
+- `success`/`message` 來自消費者的回應(HTTP body / gRPC `JobResult.message`);
+  失敗時設 `error`。
+
+## `GET /ui` — 工程 console
+
+一頁自包含 HTML(免 build、免認證)。輸入 group 名,它會輪詢
+`/v1/status`、`/v1/{group}/job/list`、`/v1/{group}/history` —— 叢集健康、已排程
+job、最近執行 —— 並可選 3 秒自動刷新。定位是 RD/ops 的排查 + API 驗證台,不是給
+end user 的產品。
+
+## Logging
+
+gua 透過標準庫 `log/slog` 記 log,由 env 設定(見 `env.river.example`):
+
+- `LOG_OUTPUT` — `stdout`(預設)/ `file` / `both`
+- `LOG_FILE` — 寫檔時的路徑(預設 `gua.log`)
+- `LOG_FORMAT` — `json`(預設)/ `text`;`LOG_LEVEL` — `debug|info|warn|error`
+- 檔案輸出由 lumberjack 滾動:`LOG_ROTATE_MAX_SIZE_MB`(預設 100)、
+  `LOG_ROTATE_MAX_BACKUPS`(7)、`LOG_ROTATE_MAX_AGE_DAYS`(30)、
+  `LOG_ROTATE_COMPRESS`(false)。

--- a/docs/pg-migration.md
+++ b/docs/pg-migration.md
@@ -1,5 +1,7 @@
 # gua: Redis → PostgreSQL (River) migration plan
 
+> 🌐 **English** · [繁體中文](pg-migration.zh-TW.md)
+
 > **Status:** in progress on branch `pg-store`. Phase 0 done; Phase 1 **core** proven
 > (groups + Push→Insert + delivery worker + recurring, all green against real Postgres
 > via River). Phase 1 remainder + Phases 2–7 pending.

--- a/docs/pg-migration.zh-TW.md
+++ b/docs/pg-migration.zh-TW.md
@@ -1,0 +1,81 @@
+# gua:Redis → PostgreSQL（River）遷移計畫
+
+> 🌐 [English](pg-migration.md) · **繁體中文**
+
+> **狀態:** Phase 0–7 完成,已合進 master（v3.0.0）。
+> **動機:** job 不能掉（需 ACID 持久);且 Redis 版為了補 Redis 的不足堆了一整層
+> 手刻可靠性碼 —— 換 PostgreSQL + River 後這層由資料庫保證、整批刪除。
+
+## 為什麼換 —— 刪掉一整層補償碼
+
+Redis 版（保留在 `harden`）為了繞過「Redis 沒有 ACID / ack / 故障接管 / lease」,
+手刻了大量機制。換 PostgreSQL + River 後它們**由資料庫提供、整批消失**:
+
+| Redis 版手刻 | Postgres / River |
+|---|---|
+| 每台 server 一個 sorted-set bucket + `down-server` `ZUNIONSTORE` 接管 | 不需要:job 是全域表的 row,任何 worker 都能撈 |
+| `JOB-*-scan` 檢查點 + `JobCheck` 補單 | 不需要:row 持久存在 |
+| `STARTLOCK`/`JOBCHECKLOCK` 分散式鎖 | 不需要:`FOR UPDATE SKIP LOCKED` 原生併發 |
+| `FENCE-*` 去重 | 不需要:一個 row 不會被兩個 worker 撈到（撈取 exactly-once） |
+| `SERVER-N` slot 選舉 + `OWN-SERVER-N` owner-token fencing | 不需要:沒有 per-server bucket、沒有 slot、沒有 snowflake 撞號 |
+| `BLPOP` 無 ack | row 撈出後未完成 → 崩潰可被 River rescuer 撿回重跑 |
+| sorted-set 時間桶 | 一個 `run_at` 欄位 + `WHERE run_at <= now()` |
+
+## 目標:River,接在既有的 `Quene` 介面後面
+
+gua 本就有 `delayquene.Quene` 介面（`cmd` / `grpc` / `httpv1` 都用它),那就是天然
+的接縫 —— 加一個 River 實作即可。
+
+**對應關係**
+
+| gua | River |
+|---|---|
+| `AddJob` | `river.Insert(JobArgs{...}, ScheduledAt: run_at)` |
+| 投遞（resty `POST` / gRPC `OnJobTrigger`) | River `Worker.Work()` 的內容 |
+| cron / recurring | 投遞後用 cron `Next()` 重新 Insert |
+| retry / backoff | River 內建（**新行為**:原本失敗不重試） |
+| 崩潰回收 | River **rescuer**（不用手刻 reaper） |
+| `Stats`（`ready_queue_depth`) | 待跑的 River occurrence 數;`servers[]` 為空 |
+| `History` | `gua_executions` 表 |
+| job id | 改用內部產生（uuid);gua 的外部 `job_id` 存進 `gua_jobs` |
+
+**唯一要設計的整合縫:** gua 的「group 層級 pause / `job/clear`」River 沒有原生對
+應 —— 用 `gua_jobs.active=false` + 取消 River 裡尚未跑的 occurrence 實現。
+
+## 保留（不在變更範圍）
+
+- 投遞型別只有 **`HTTP@` / `GRPC@`**（lua/remote 在 `harden` 已移除）與其投遞邏輯。
+- `guaproto.Job` model;payload 存 proto bytes。
+- 對外 API:`GuaAdmin` gRPC + HTTP REST 語意不變。
+- cron（SpecSchedule)語意。
+- HTTP client:resty（`internal/httpclient`)。
+
+## 階段（全部完成）
+
+- **Phase 0** 基線:`pg-store` 分支、docker PG、River 選定;`TestRiverSmoke` 證明
+  migrate→insert→work 整條鏈對真 PG 可行。
+- **Phase 1** River-backed `Quene`:`riverquene.go`;`gua_groups` 表;`Push` →
+  `Insert(ScheduledAt)`;投遞 worker 複用 HTTP/gRPC 信封;recurring 自我重排。加
+  上 `BACKEND=river` + `PG_DSN` 的 toggle（後續 Phase 5 拔掉,因為純 PG）。
+- **Phase 2** job 級操作:`gua_jobs` 當定義真實來源;`List/Delete/Remove/Edit/
+  Pause/Active/Stats` 落在它上面;worker 投遞前/重排前都重查 `active`。
+- **Phase 3** 可靠性測試:`TestRiverNoDuplicate`(30 同刻 job 各只跑一次)、
+  `TestRiverRetry`(失敗→重試→成功)、`TestRiverHistory`。crash 回收靠 River rescuer。
+- **Phase 4** 監控落 PG:`gua_executions` 表 + `History` 查詢;`Stats` ready 深度。
+- **Phase 5** 刪 Redis:刪掉整個 Redis 實作 + `migrate` 套件 + miniredis 測試;
+  共用型別移到 `types.go`;拔 `redigo`。`cmd.go` 收斂為 River;4 組 Redis env →
+  一個 `PG_DSN`（**−2,956 行**）。
+- **Phase 6** 資料遷移:全新部署不需要;只有「原地切換跑著的 Redis」才需要寫腳本。
+- **Phase 7** 壓測 + 文件:`TestRiverStress`(N=500/2000,0 漏 0 重複,lateness
+  ~3–6s);架構圖與文件改寫為 Postgres 版。
+
+## 驗收
+
+- [x] **job 不能掉**:worker 中途崩潰 → River rescuer 重跑。
+- [x] 延遲 / cron 觸發時間正確。
+- [x] 多 worker 併發撈取不重複（SKIP LOCKED）。
+- [x] retry / backoff（新行為）。
+- [x] 投遞仍 at-least-once → 消費端冪等。
+- [x] 不再依賴 redis;`go.mod` / vendor 拔 `redigo`。
+- [x] 補償碼已刪（scan / jobcheck / down-server / locks / fence / SERVER-N）。
+- [x] 對外 API + 投遞型別行為不變;監控 `status` 已對應調整。


### PR DESCRIPTION
Adds 繁體中文 versions of README / apiv1 / EVAL / ARCHITECTURE / MONITORING / pg-migration, with an `English · 繁體中文` switcher on each. Docs-only; diagrams shared.