### PR TITLE
docs: language-switcher badges on README (EN/繁中)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # gua
 
-> 🌐 **English** · [繁體中文](docs/README.zh-TW.md)
+[![docs: English](https://img.shields.io/badge/docs-English-blue)](README.md)
+[![docs: 繁體中文](https://img.shields.io/badge/docs-%E7%B9%81%E9%AB%94%E4%B8%AD%E6%96%87-lightgrey)](docs/README.zh-TW.md)
+[![Go](https://img.shields.io/github/go-mod/go-version/syhlion/gua)](go.mod)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 Distributed crontab-style scheduler in Go, backed by **PostgreSQL** (via
 [River](https://riverqueue.com)).

--- a/docs/README.zh-TW.md
+++ b/docs/README.zh-TW.md
@@ -1,6 +1,9 @@
 # gua
 
-> 🌐 [English](../README.md) · **繁體中文**
+[![docs: English](https://img.shields.io/badge/docs-English-lightgrey)](../README.md)
+[![docs: 繁體中文](https://img.shields.io/badge/docs-%E7%B9%81%E9%AB%94%E4%B8%AD%E6%96%87-blue)](README.zh-TW.md)
+[![Go](https://img.shields.io/github/go-mod/go-version/syhlion/gua)](../go.mod)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](../LICENSE)
 
 以 Go 實作的分散式 crontab 風格排程器,後端為 **PostgreSQL**(透過
 [River](https://riverqueue.com))。


### PR DESCRIPTION
Replaces the plain-text language switcher at the top of both READMEs with a shields.io **badge row**:

- `docs: English` ⇄ `docs: 繁體中文` — the active language renders solid (blue), the other links across. Mirrored on the zh-TW README with colours swapped.
- `Go` — dynamic badge reading `go.mod` (auto-updates).
- `License: MIT`.

All four badge URLs verified to return `200` (incl. the URL-encoded 繁體中文 label and the dynamic go-version endpoint).

Separately (not in this diff, already applied to the repo): refreshed the GitHub **About** description + topics to match the v3 stack — was still the pre-v3 *"Support crontab style Schedule System implement by golang"*; now *"Distributed crontab-style job scheduler in Go, backed by PostgreSQL (River); HTTP/gRPC trigger delivery."* with topics `postgresql, river, grpc, job-scheduler, distributed-systems, cron` added.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)