### PR TITLE
perf(grpc): reuse pooled delivery connections instead of dial-per-trigger

### DIFF
--- a/cmdriver.go
+++ b/cmdriver.go
@@ -17,6 +17,7 @@ import (
 	guaproto "github.com/syhlion/gua/proto"
 	"github.com/urfave/cli"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 )
 
@@ -67,7 +68,20 @@ func startRiver(c *cli.Context) {
 	if err != nil {
 		logFatal(logger, "startup error", "error", err)
 	}
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(
+		// Keep idle delivery connections (now pooled & long-lived on the gua
+		// side) alive through NAT/LB paths, and detect dead peers.
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    60 * time.Second,
+			Timeout: 20 * time.Second,
+		}),
+		// Don't drop clients that ping while idle — the delivery pool keeps
+		// connections without an active stream between triggers.
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             20 * time.Second,
+			PermitWithoutStream: true,
+		}),
+	)
 	guaproto.RegisterGuaAdminServer(grpcServer, &GuaAdmin{quene: quene})
 	reflection.Register(grpcServer)
 

--- a/delayquene/grpcpool.go
+++ b/delayquene/grpcpool.go
@@ -1,0 +1,64 @@
+package delayquene
+
+import (
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+)
+
+// grpcClientPool caches one *grpc.ClientConn per delivery target so recurring
+// jobs reuse a single HTTP/2 connection instead of dialling — and tearing the
+// connection down — on every trigger. gRPC ClientConns are goroutine-safe and
+// multiplex concurrent RPCs, so one per target is enough.
+type grpcClientPool struct {
+	mu    sync.RWMutex
+	conns map[string]*grpc.ClientConn
+}
+
+func newGrpcClientPool() *grpcClientPool {
+	return &grpcClientPool{conns: make(map[string]*grpc.ClientConn)}
+}
+
+// conn returns a cached ClientConn for target, creating one on first use.
+// grpc.NewClient is lazy — the actual transport is established on the first RPC
+// (governed by that RPC's context), so this never blocks on the network.
+func (p *grpcClientPool) conn(target string) (*grpc.ClientConn, error) {
+	p.mu.RLock()
+	c, ok := p.conns[target]
+	p.mu.RUnlock()
+	if ok {
+		return c, nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if c, ok := p.conns[target]; ok { // re-check: another goroutine may have won
+		return c, nil
+	}
+	c, err := grpc.NewClient(target,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                30 * time.Second, // ping idle conns to keep NAT/LB paths open
+			Timeout:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
+	)
+	if err != nil {
+		return nil, err
+	}
+	p.conns[target] = c
+	return c, nil
+}
+
+// Close tears down every pooled connection. Called on queue shutdown.
+func (p *grpcClientPool) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, c := range p.conns {
+		_ = c.Close()
+	}
+	p.conns = make(map[string]*grpc.ClientConn)
+}

--- a/delayquene/riverquene.go
+++ b/delayquene/riverquene.go
@@ -17,7 +17,6 @@ import (
 	"github.com/riverqueue/river/rivermigrate"
 	"github.com/syhlion/gua/internal/httpclient"
 	guaproto "github.com/syhlion/gua/proto"
-	"google.golang.org/grpc"
 	"log/slog"
 	"resty.dev/v3"
 )
@@ -53,6 +52,7 @@ type guaDeliverWorker struct {
 	river.WorkerDefaults[guaJobArgs]
 	pool        *pgxpool.Pool
 	httpClient  *resty.Client
+	grpcPool    *grpcClientPool
 	machineHost string
 	machineMac  string
 	machineIp   string
@@ -103,7 +103,7 @@ func (w *guaDeliverWorker) Work(ctx context.Context, job *river.Job[guaJobArgs])
 	// River's occurrence id is stable across retries/rescues of THIS firing —
 	// hand it to the consumer as the idempotency key.
 	idemKey := strconv.FormatInt(job.ID, 10)
-	resp, derr := deliver(ctx, w.httpClient, a, idemKey)
+	resp, derr := deliver(ctx, w.httpClient, w.grpcPool, a, idemKey)
 	w.recordExecution(ctx, a, execTime, resp, derr)
 	if derr != nil {
 		w.logger.Error("river delivery error", "job", a.JobId, "error", derr)
@@ -137,7 +137,7 @@ func (w *guaDeliverWorker) Work(ctx context.Context, job *river.Job[guaJobArgs])
 
 // deliver sends the trigger envelope to the consumer and returns the result
 // message. idemKey is stable across re-deliveries of this firing.
-func deliver(ctx context.Context, httpClient *resty.Client, a guaJobArgs, idemKey string) (string, error) {
+func deliver(ctx context.Context, httpClient *resty.Client, grpcPool *grpcClientPool, a guaJobArgs, idemKey string) (string, error) {
 	ss := UrlRe.FindStringSubmatch(a.RequestUrl)
 	if len(ss) == 0 {
 		return "", fmt.Errorf("invalid request_url %q", a.RequestUrl)
@@ -167,11 +167,11 @@ func deliver(ctx context.Context, httpClient *resty.Client, a guaJobArgs, idemKe
 		if timeout <= 0 {
 			timeout = 5 * time.Second
 		}
-		conn, err := grpc.Dial(ss[2], grpc.WithInsecure())
+		conn, err := grpcPool.conn(ss[2])
 		if err != nil {
 			return "", err
 		}
-		defer conn.Close()
+		// conn is pooled and reused across triggers — do NOT close it here.
 		cctx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		res, err := guaproto.NewGuaCallbackClient(conn).OnJobTrigger(cctx, &guaproto.JobTrigger{
@@ -196,9 +196,10 @@ func deliver(ctx context.Context, httpClient *resty.Client, a guaJobArgs, idemKe
 }
 
 type riverQuene struct {
-	pool   *pgxpool.Pool
-	client *river.Client[pgx.Tx]
-	logger *slog.Logger
+	pool     *pgxpool.Pool
+	client   *river.Client[pgx.Tx]
+	grpcPool *grpcClientPool
+	logger   *slog.Logger
 }
 
 // NewRiver builds a Postgres/River-backed Quene: runs River migrations, creates
@@ -263,9 +264,11 @@ func NewRiver(cfg *RiverConfig) (Quene, error) {
 		return nil, err
 	}
 
+	grpcPool := newGrpcClientPool()
 	work := &guaDeliverWorker{
 		pool:        pool,
 		httpClient:  httpclient.New(60*time.Second, false),
+		grpcPool:    grpcPool,
 		machineHost: cfg.MachineHost,
 		machineMac:  cfg.MachineMac,
 		machineIp:   cfg.MachineIp,
@@ -292,7 +295,7 @@ func NewRiver(cfg *RiverConfig) (Quene, error) {
 		pool.Close()
 		return nil, err
 	}
-	return &riverQuene{pool: pool, client: client, logger: cfg.Logger}, nil
+	return &riverQuene{pool: pool, client: client, grpcPool: grpcPool, logger: cfg.Logger}, nil
 }
 
 func genID() string {
@@ -307,6 +310,7 @@ func (q *riverQuene) Close() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	_ = q.client.Stop(ctx)
+	q.grpcPool.Close()
 	q.pool.Close()
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,15 @@
   "job not lost" acceptance item from the Postgres migration. Gated by
   `GUA_PG_DSN`; runs in CI against `postgres:16`.
 
+[Changed / hardened]
+
+* gRPC delivery now **reuses a pooled `*grpc.ClientConn` per target** instead of
+  dialling and tearing down a connection on every trigger. Recurring jobs hitting
+  the same consumer no longer pay a TCP+HTTP/2 handshake each fire. Also replaces
+  the deprecated `grpc.Dial`/`grpc.WithInsecure` with `grpc.NewClient`/
+  `insecure.NewCredentials`, and adds client + server keepalive so pooled idle
+  connections survive NAT/LB paths and dead peers are detected.
+
 [Docs]
 
 * recorded the decision to keep durable self-rescheduling (next occurrence as a


### PR DESCRIPTION
## Problem
gRPC delivery did `grpc.Dial(target)` → one RPC → `conn.Close()` on **every** trigger, while the HTTP branch reused a shared client. Recurring jobs hitting the same consumer paid a TCP + HTTP/2 handshake each fire. The calls also used the deprecated `grpc.Dial`/`grpc.WithInsecure`.

## Change
- **`grpcClientPool`** (new `delayquene/grpcpool.go`): one lazy `*grpc.ClientConn` per target, reused across triggers (ClientConns are goroutine-safe and multiplex concurrent RPCs), torn down on queue shutdown.
- Delivery pulls from the pool; the connection is **not** closed after each RPC.
- Swap deprecated `grpc.Dial`/`grpc.WithInsecure` → `grpc.NewClient`/`insecure.NewCredentials` (what the e2e test already used).
- Add **client + server keepalive** so pooled idle connections survive NAT/LB paths and dead peers are detected.

## Verification
`go build` / `go vet` clean, `go mod tidy` no-op, unit tests pass, and the full e2e — including the `gRPC register+add → gRPC delivery` subtest — passes against `postgres:16`.

First of a 5-PR API-modernization series (this one is independent and lowest-risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)