### PR TITLE
chore(release): stamp v4.0.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 [unrelease]
 
+[v4.0.0]
+
+> **Breaking**: HTTP REST API redesigned to a clean resource-oriented shape under
+> `/v1` (groups/jobs as nested resources). gRPC `GuaAdmin` contract unchanged. No
+> external consumers yet — hard cutover, no aliases.
+
 [Changed / API]
 
 * **REST API redesigned to a clean resource-oriented shape** and moved off


### PR DESCRIPTION
Stamps the modernization work as **v4.0.0** (breaking major bump from v3.2.0): clean resource-oriented REST API under `/v1` (groups/jobs nested resources) on stdlib net/http, plus the gRPC delivery connection-reuse. gRPC `GuaAdmin` contract unchanged. Moves the CHANGELOG `[unrelease]` block under `[v4.0.0]`. Tag pushed after merge → Drone builds `syhlion/gua:4.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)