### PR TITLE
docs(example): add one-command scheduler demo

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,41 @@
+# gua example — scheduler demo
+
+A one-command, self-contained demo: set a delay + payload in the browser, and
+**watch gua fire the job** live. It shows the whole path — schedule → gua stores
+& waits → fires → delivers to a consumer webhook → back to the page — with no
+setup.
+
+## Run
+
+From the repo root:
+
+```sh
+docker compose -f example/docker-compose.yml up --build
+```
+
+Then open **<http://localhost:8080>**.
+
+- **Left pane (backend → schedule)** — set *fire after N seconds* and a *payload*,
+  hit *schedule*. The demo backend registers a group and schedules a one-shot job
+  in gua: `POST /v1/groups/demo/jobs` with `request_url` pointing at its own
+  `/hook`.
+- **Right pane (frontend → live effect)** — an SSE stream. You'll see
+  **⏱ scheduled** immediately, then **🔥 FIRED** when gua delivers the job to the
+  webhook after the delay.
+
+## What's in the stack
+
+| Service | Role |
+|---|---|
+| `postgres` | gua's only backend (River runs its own migrations) |
+| `gua` (`:7777`, internal) | the scheduler — the demo schedules jobs via its REST API |
+| `demo` (`:8080`) | tiny stdlib Go backend: serves the page, schedules jobs, receives gua's delivery webhook, streams events to the browser (SSE) |
+
+## Notes
+
+- The job is **one-shot** (`@once`); try a cron / `@every` pattern by changing
+  `interval_pattern` in `app/main.go`.
+- Delivery is **at-least-once** and carries an `idempotency_key` — see the full
+  API in [../docs/apiv1.md](../docs/apiv1.md).
+- Demo only — no auth, fixed group (`demo`). For real use, point `request_url` at
+  your own consumer (HTTP or gRPC).

--- a/example/app/Dockerfile
+++ b/example/app/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+COPY main.go .
+RUN go mod init gua-example && CGO_ENABLED=0 go build -o /demo .
+
+FROM alpine:3.20
+WORKDIR /app
+COPY --from=build /demo ./demo
+COPY static ./static
+EXPOSE 8080
+ENTRYPOINT ["./demo"]

--- a/example/app/main.go
+++ b/example/app/main.go
@@ -1,0 +1,169 @@
+// Command demo is a tiny backend for the gua example: it serves the single-page
+// UI, schedules jobs in gua on request, and receives gua's delivery webhook —
+// streaming "scheduled" / "fired" events to the browser over SSE so you can
+// watch a job fire. Pure stdlib — no dependencies.
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+const group = "demo"
+
+var (
+	guaURL  string
+	hookURL string
+	sse     = &broker{clients: map[chan string]bool{}}
+)
+
+func env(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	guaURL = env("GUA_URL", "http://localhost:7777")
+	hookURL = env("HOOK_URL", "http://localhost:8080/hook")
+	staticDir := env("STATIC_DIR", "static")
+	addr := env("LISTEN", ":8080")
+
+	ensureGroup() // best-effort; also retried per schedule
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /", http.FileServer(http.Dir(staticDir)))
+	mux.HandleFunc("POST /schedule", handleSchedule)
+	mux.HandleFunc("POST /hook", handleHook) // gua delivers fired jobs here
+	mux.HandleFunc("GET /events", handleEvents)
+
+	log.Printf("gua example demo listening on %s (gua=%s, hook=%s)", addr, guaURL, hookURL)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+// handleSchedule registers a one-shot gua job that fires after `delay` seconds
+// and delivers `payload` back to our /hook.
+func handleSchedule(w http.ResponseWriter, r *http.Request) {
+	var in struct {
+		Delay   int    `json:"delay"`
+		Payload string `json:"payload"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	if in.Delay < 0 {
+		in.Delay = 0
+	}
+	ensureGroup()
+	execTime := time.Now().Unix() + int64(in.Delay)
+	job := map[string]any{
+		"name":             "demo-job",
+		"exec_time":        execTime,
+		"interval_pattern": "@once",
+		"request_url":      "HTTP@" + hookURL,
+		"payload":          in.Payload,
+	}
+	body, _ := json.Marshal(job)
+	resp, err := http.Post(guaURL+"/v1/groups/"+group+"/jobs", "application/json", bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, "schedule failed: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		http.Error(w, "gua rejected: "+string(rb), http.StatusBadGateway)
+		return
+	}
+	sse.broadcast(map[string]any{"type": "scheduled", "payload": in.Payload, "delay": in.Delay, "at": execTime})
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(rb) // gua returns the job id
+}
+
+// handleHook is the consumer endpoint gua POSTs to when a job fires.
+func handleHook(w http.ResponseWriter, r *http.Request) {
+	var env struct {
+		Payload  string `json:"payload"`
+		JobId    string `json:"job_id"`
+		ExecTime int64  `json:"exec_time"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&env)
+	sse.broadcast(map[string]any{"type": "fired", "payload": env.Payload, "job_id": env.JobId, "at": env.ExecTime})
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}
+
+// handleEvents is the browser's SSE stream.
+func handleEvents(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "stream unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	ch := sse.sub()
+	defer sse.unsub(ch)
+	fmt.Fprintf(w, "data: %s\n\n", `{"type":"ready"}`)
+	flusher.Flush()
+	for {
+		select {
+		case msg := <-ch:
+			fmt.Fprintf(w, "data: %s\n\n", msg)
+			flusher.Flush()
+		case <-r.Context().Done():
+			return
+		}
+	}
+}
+
+func ensureGroup() {
+	body, _ := json.Marshal(map[string]any{"group_name": group})
+	resp, err := http.Post(guaURL+"/v1/groups", "application/json", bytes.NewReader(body))
+	if err == nil {
+		resp.Body.Close()
+	}
+}
+
+// broker is a minimal SSE fan-out.
+type broker struct {
+	mu      sync.Mutex
+	clients map[chan string]bool
+}
+
+func (b *broker) sub() chan string {
+	ch := make(chan string, 16)
+	b.mu.Lock()
+	b.clients[ch] = true
+	b.mu.Unlock()
+	return ch
+}
+func (b *broker) unsub(ch chan string) {
+	b.mu.Lock()
+	if b.clients[ch] {
+		delete(b.clients, ch)
+		close(ch)
+	}
+	b.mu.Unlock()
+}
+func (b *broker) broadcast(v any) {
+	data, _ := json.Marshal(v)
+	b.mu.Lock()
+	for ch := range b.clients {
+		select {
+		case ch <- string(data):
+		default:
+		}
+	}
+	b.mu.Unlock()
+}

--- a/example/app/static/index.html
+++ b/example/app/static/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>gua — scheduler demo</title>
+<style>
+ :root{color-scheme:dark}
+ body{font:14px/1.5 system-ui,monospace;margin:0;background:#0b0e14;color:#c9d1d9}
+ header{padding:14px 20px;border-bottom:1px solid #2d333b}
+ header h1{font-size:18px;margin:0}
+ header .sub{color:#8b949e;font-size:13px}
+ .wrap{display:flex;gap:16px;padding:20px;flex-wrap:wrap}
+ .pane{flex:1;min-width:320px;border:1px solid #2d333b;border-radius:8px;background:#0d1117}
+ .pane h2{font-size:14px;margin:0;padding:10px 14px;border-bottom:1px solid #2d333b;color:#7ee787}
+ .pane .body{padding:14px}
+ label{display:block;color:#8b949e;font-size:12px;margin:10px 0 4px}
+ input,button{font:14px system-ui;border:1px solid #2d333b;border-radius:6px;background:#161b22;color:#c9d1d9;padding:8px 10px;width:100%;box-sizing:border-box}
+ button{background:#238636;border-color:#238636;color:#fff;cursor:pointer;margin-top:14px}
+ button:hover{background:#2ea043}
+ #status{font-size:12px;color:#8b949e;margin-bottom:10px}
+ #status b.ok{color:#3fb950} #status b.bad{color:#f85149}
+ #log{list-style:none;margin:0;padding:0;max-height:50vh;overflow:auto}
+ #log li{padding:8px 10px;border:1px solid #21262d;border-radius:6px;margin-bottom:6px;background:#161b22}
+ #log li .t{color:#8b949e;font-size:11px}
+ #log li.sched{border-left:3px solid #d29922}
+ #log li.fired{border-left:3px solid #3fb950}
+ #log li .m{color:#e6edf3;font-size:15px;word-break:break-word}
+ .muted{color:#8b949e}
+</style>
+</head>
+<body>
+<header>
+ <h1>gua — distributed scheduler demo</h1>
+ <div class="sub">configure a job on the left → gua schedules it → when it fires, gua delivers it back and you see it live on the right</div>
+</header>
+<div class="wrap">
+ <section class="pane">
+  <h2>① backend — schedule a job</h2>
+  <div class="body">
+   <div class="muted">gua will fire a one-shot job after the delay and deliver the payload to this demo's webhook.</div>
+   <label>fire after (seconds)</label>
+   <input id="delay" type="number" value="5" min="0">
+   <label>payload</label>
+   <input id="payload" value="hello from gua" autocomplete="off">
+   <button onclick="schedule()">schedule</button>
+   <div id="schedstatus" class="muted" style="margin-top:10px"></div>
+  </div>
+ </section>
+ <section class="pane">
+  <h2>② frontend — live effect</h2>
+  <div class="body">
+   <div id="status">connecting…</div>
+   <ul id="log"></ul>
+  </div>
+ </section>
+</div>
+<script>
+const $=id=>document.getElementById(id);
+const ts=()=>new Date().toLocaleTimeString();
+function add(cls,html){const li=document.createElement('li');li.className=cls;li.innerHTML='<div class="t">'+ts()+'</div><div class="m">'+html+'</div>';$('log').prepend(li);}
+function esc(s){return String(s).replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));}
+
+const es=new EventSource('/events');
+es.onopen=()=>$('status').innerHTML='event stream <b class=ok>live</b>';
+es.onerror=()=>$('status').innerHTML='event stream <b class=bad>reconnecting…</b>';
+es.onmessage=e=>{
+ let m; try{m=JSON.parse(e.data);}catch(_){return;}
+ if(m.type==='scheduled'){add('sched','⏱ <b>scheduled</b> — fires in '+m.delay+'s · payload: <code>'+esc(m.payload)+'</code>');}
+ else if(m.type==='fired'){add('fired','🔥 <b>FIRED</b> — gua delivered payload: <code>'+esc(m.payload)+'</code> <span class=muted>(job '+esc(m.job_id)+')</span>');}
+};
+
+async function schedule(){
+ const delay=parseInt($('delay').value||'0',10), payload=$('payload').value;
+ $('schedstatus').textContent='scheduling…';
+ const r=await fetch('/schedule',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({delay,payload})});
+ $('schedstatus').textContent=r.ok?('scheduled ✓ — watch the right pane in '+delay+'s'):('failed: '+(await r.text()));
+}
+</script>
+</body>
+</html>

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,0 +1,46 @@
+# gua scheduler demo — postgres + gua + a tiny demo backend.
+# Run from the repo root:
+#   docker compose -f example/docker-compose.yml up --build
+# then open http://localhost:8080
+#
+# Configure a job in the browser → the demo backend schedules it in gua → when it
+# fires, gua delivers it to the demo's webhook, which streams it back to the page.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: gua
+      POSTGRES_DB: gua
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d gua"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  gua:
+    build: ..
+    command: start
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      GRPC_LISTEN: ":6666"
+      HTTP_LISTEN: ":7777"
+      MACHINE_CODE: gua-demo
+      PG_DSN: "postgres://postgres:gua@postgres:5432/gua?sslmode=disable"
+      LOG_OUTPUT: stdout
+      LOG_FORMAT: json
+      LOG_LEVEL: info
+
+  demo:
+    build:
+      context: ./app
+    environment:
+      GUA_URL: "http://gua:7777"
+      HOOK_URL: "http://demo:8080/hook" # gua delivers fired jobs here (compose network)
+      LISTEN: ":8080"
+    ports:
+      - "8080:8080" # the demo UI
+    depends_on:
+      - gua


### PR DESCRIPTION
Adds `example/` — a self-contained, one-command interactive demo of the scheduler.

```sh
docker compose -f example/docker-compose.yml up --build   # then open http://localhost:8080
```

- **Left pane** (backend → schedule): set *fire after N seconds* + *payload* → demo backend schedules a one-shot job in gua (`POST /v1/groups/demo/jobs`, `request_url` = its own `/hook`).
- **Right pane** (frontend → live effect): an SSE stream shows **⏱ scheduled** immediately, then **🔥 FIRED** when gua delivers the job after the delay.

**Stack**: postgres + gua + a tiny **stdlib-only** Go demo backend (`example/app/main.go`) that serves the page, schedules jobs, receives gua's delivery webhook, and streams events to the browser (SSE). Single-page split UI, vanilla JS, no build step.

**Verified** against the running stack: a 3s job produced an SSE `scheduled` event immediately and a `fired` event ~3s later carrying the delivered payload + job id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)