### PR TITLE
docs: link the runnable example/ demo from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Output is selectable and rotated, via env:
 
 ## Docs
 
+- [example/](example/) — **runnable demo**: configure a job, watch gua fire it live (one `docker compose` command)
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — architecture, pipeline, HA (with diagrams)
 - [docs/apiv1.md](docs/apiv1.md) — admin REST API
 - [`proto/gua.proto`](./proto/gua.proto) — gRPC `GuaAdmin` + `GuaCallback`

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -99,6 +99,7 @@ $ ./gua start                    # 或直接讀 process 環境變數
 
 ## 文件
 
+- [example/](example/) — **可直接跑的 demo**：設定一個 job、即時看 gua 觸發它（一行 `docker compose` 啟動）
 - [docs/ARCHITECTURE.zh-TW.md](docs/ARCHITECTURE.zh-TW.md) — 架構、pipeline、HA(含圖)
 - [docs/apiv1.zh-TW.md](docs/apiv1.zh-TW.md) — admin REST API
 - [`proto/gua.proto`](./proto/gua.proto) — gRPC `GuaAdmin` + `GuaCallback`


### PR DESCRIPTION
Adds a Docs-section link (EN + zh) pointing at the new `example/` scheduler demo. The standalone walkthrough lives in `example/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)