### PR TITLE
ci(drone): add Telegram notify + cut PR/branch noise

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,14 @@ kind: pipeline
 type: docker
 name: default
 
+# Only build master pushes, tags, and pull requests — not every feature/docs
+# branch push. ref-based so tag builds are never filtered out by a branch rule.
+trigger:
+  ref:
+    - refs/heads/master
+    - refs/tags/**
+    - refs/pull/**
+
 # A Postgres service is started alongside the pipeline so the River/Postgres
 # integration tests in delayquene actually run (they skip when GUA_PG_DSN is
 # unset). The test step waits for it to accept connections before running.
@@ -41,8 +49,27 @@ steps:
       password:
         from_secret: docker_password
     when:
-      branch:
-        - master
       event:
         - push
         - tag
+
+  - name: notify
+    image: appleboy/drone-telegram
+    settings:
+      message: >
+          {{#success build.status}}
+              {{repo.namespace}}/{{repo.name}} build {{build.number}}. commit {{commit.sha}} succeeded. Good job.
+              {{else}}
+              {{repo.namespace}}/{{repo.name}} build {{build.number}}. commit {{commit.sha}} failed. Fix me please.
+          {{/success}}
+      token:
+        from_secret: bot_token
+      to:
+        from_secret: bot_to
+    when:
+      event:
+        - push
+        - tag
+      status:
+        - failure
+        - success


### PR DESCRIPTION
Brings gua's Drone pipeline in line with gusher's and roots out the noise:

- **Telegram notify step** — gua had none; adds one (same template as gusher), gated to `event: [push, tag]` (no PR alerts). Uses `bot_token` / `bot_to` secrets.
- **ref-based `trigger`** (`refs/heads/master` + `refs/tags/**` + `refs/pull/**`) — feature/docs branch pushes no longer spawn builds.
- **docker** step: drop the `branch: master` filter (the trigger handles branches now), keeping `event: [push, tag]`. A step-level `branch: master` can silently drop **tag** events — a likely reason gua has published **no tag image since 2024**. This should let the `v4.0.0` tag build actually push.

> Needs `bot_token` / `bot_to` (and `docker_account` / `docker_password`) secrets configured on the gua Drone repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)