### PR TITLE
ci(drone): build only master + tags (drop PR builds)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,13 +3,14 @@ kind: pipeline
 type: docker
 name: default
 
-# Only build master pushes, tags, and pull requests — not every feature/docs
-# branch push. ref-based so tag builds are never filtered out by a branch rule.
+# Build only master pushes and tags — not PRs or feature/docs branch pushes
+# (solo dev, local testing, slow capacity=1 queue). The master build's test step
+# gates the docker push, so a broken merge never publishes a bad image.
+# ref-based so tag builds are never filtered out by a branch rule.
 trigger:
   ref:
     - refs/heads/master
     - refs/tags/**
-    - refs/pull/**
 
 # A Postgres service is started alongside the pipeline so the River/Postgres
 # integration tests in delayquene actually run (they skip when GUA_PG_DSN is


### PR DESCRIPTION
Follow-up: each change was building twice (PR + merge). On a slow capacity=1 runner with local testing, the PR build only duplicated the master build's `test` (which already gates the docker push). Drop `refs/pull/**` so a change builds **once** (on merge to master) or on a tag. A broken merge still fails `test` → no image push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)