### PR TITLE
ci: stamp release version into the image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,6 +45,8 @@ steps:
       repo: syhlion/gua
       auto_tag: true
       purge: true
+      build_args:
+        - VERSION=${DRONE_SEMVER}
       username:
         from_secret: docker_account
       password:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@
 FROM golang:1.25-alpine AS builder
 LABEL stage=gua-intermediate
 ENV CGO_ENABLED=0
+# VERSION is stamped into main.version (shown by GET /version); passed from CI as
+# the release tag, empty for non-tag (:latest) builds.
+ARG VERSION
 RUN apk add --no-cache git make
 ADD ./ /go/src/gua
-RUN cd /go/src/gua && go build -mod vendor -o /gua
+RUN cd /go/src/gua && go build -mod vendor -ldflags "-X main.version=${VERSION}" -o /gua
 
 # final stage
 FROM alpine:3.20


### PR DESCRIPTION
From the CI review: the published `syhlion/gua` image reported an empty `GET /version` even for tagged releases (the Dockerfile set no ldflags). Now `ARG VERSION` → `-ldflags -X main.version`, fed by the docker step's `build_args: VERSION=${DRONE_SEMVER}` (→ `4.0.0` on a tag build, empty on `:latest`).

Verified: `docker build --build-arg VERSION=9.9.9-test` → `--version` prints `version 9.9.9-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)