### PR TITLE
ci: run tests under -race; stamp main.name into the image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,16 +25,18 @@ services:
 
 steps:
   - name: test
-    image: golang:1.25-alpine
+    # Debian image (glibc + gcc) so `go test -race` works — the race detector
+    # needs cgo and is unreliable on alpine/musl.
+    image: golang:1.25
     environment:
-      CGO_ENABLED: "0"
+      CGO_ENABLED: "1" # required by the race detector (prod image stays CGO=0)
       GUA_PG_DSN: postgres://gua:gua@database:5432/gua?sslmode=disable
     commands:
-      - apk add --no-cache git postgresql-client
+      - apt-get update && apt-get install -y --no-install-recommends postgresql-client
       - until pg_isready -h database -U gua -d gua; do echo "waiting for postgres"; sleep 1; done
       - go build ./...
       - go vet ./...
-      - go test ./...
+      - go test -race ./...
 
   # Build and push the runtime image. Releases (git tags + GitHub Release notes)
   # are cut manually with the gh CLI, so there is no auto github-release step

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV CGO_ENABLED=0
 ARG VERSION
 RUN apk add --no-cache git make
 ADD ./ /go/src/gua
-RUN cd /go/src/gua && go build -mod vendor -ldflags "-X main.version=${VERSION}" -o /gua
+RUN cd /go/src/gua && go build -mod vendor -ldflags "-X main.name=gua -X main.version=${VERSION}" -o /gua
 
 # final stage
 FROM alpine:3.20


### PR DESCRIPTION
Two follow-ups from the CI review:

- **`-race` in CI** — switch the test step to the Debian `golang:1.25` image (glibc + gcc) with `CGO_ENABLED=1` so `go test -race ./...` runs (the detector is unreliable on alpine/musl). Prod image stays `CGO=0`. Verified locally: `-race` passes clean (root e2e + delayquene/River) against `postgres:16`, no data races.
- **`main.name`** — stamp `-X main.name=gua` so the image's `--version` reads `gua version X` instead of ` version X`. (HTTP `/version` was already fine.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)